### PR TITLE
Fix some bones not getting collected

### DIFF
--- a/js/graveyard.js
+++ b/js/graveyard.js
@@ -365,6 +365,9 @@ BoneCollectors = {
     if (this.sprites.length > GameModel.persistentData.boneCollectors) {
       var boneCollector = this.sprites.pop();
       if (boneCollector.boneList) {
+        if(boneCollector.target && boneCollector.target.collector) {
+          boneCollector.target.collector = false;
+        }
         for (var i = 0; i < boneCollector.boneList.length; i++){
           boneCollector.boneList[i].collector = false;
         }


### PR DESCRIPTION
When a bone collector gets removed, but currently has a bone as target,
the bone keeps the status collector=true