### PR TITLE
Remove free brains and bones

### DIFF
--- a/js/gamemodel.js
+++ b/js/gamemodel.js
@@ -228,8 +228,6 @@ GameModel = {
     this.addEnergy(this.getEnergyRate() * timeDiff);
 
     if (this.currentState == this.states.playingLevel) {
-      this.addBones(this.bonesRate * timeDiff);
-      this.addBrains(this.brainsRate * timeDiff);
       Upgrades.updateRunicSyphon(this.runicSyphon);
       
       if (this.lastSave + 30000 < updateTime) {


### PR DESCRIPTION
By upgrading brains and bones rates (but not blood rate for blood?) players received free brains and bones every tick. 

This just removes those two lines, but leaves increased income rate upgrades intact.